### PR TITLE
Changed bootstrap level

### DIFF
--- a/deploy.drush.inc
+++ b/deploy.drush.inc
@@ -28,7 +28,7 @@ function deploy_drush_command() {
     ),
     'examples' => array(
     ),
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_SITE,
     'config' => 'deploy',
   );
 


### PR DESCRIPTION
I ran into problem with drush deploy after updating drush to the latest version.

I got:

    $drush deploy @live -v
    Please specify the name of your application                                             [error]
    Please specify the repository that houses your application's code                       [error]

I fixed this by changing the bootstrap level in the deploy_drush_command() from DRUSH_BOOTSTRAP_DRUSH to DRUSH_BOOTSTRAP_DRUPAL_SITE.

I had the same issue with my safe-sync command: if the bootrsrap level is less than DRUSH_BOOTSTRAP_DRUPAL_SITE, the aliases are not loaded from sites/default folder.

BTW, you can check https://github.com/AmazeeLabs/drush_safe_sync when you have time. Probably you'll like it ;)